### PR TITLE
Additional error checking on API calls; See #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,19 @@ helping materials file.
     pbs add_helpingmaterials --help
 ```
 
+## Running the Tests
+
+To run the test suite for pbs, first install [note](https://nose.readthedocs.io/en/latest/):
+ 
+```bash
+apt-get install python-nose
+```
+
+To run all tests, execute the following from the pbs project directory:
+
+```bash
+nosetests test
+```
 
 # Documentation
 

--- a/helpers.py
+++ b/helpers.py
@@ -361,29 +361,32 @@ def find_project_by_short_name(short_name, pbclient, all=None):
 
 
 def check_api_error(api_response):
-    """Check if returned API response contains an error."""
+    """Check if returned API response contains an error.
     if type(api_response) == dict and 'status' not in api_response:
+        if 'status_code' in api_response and api_response['status_code'] <> 200
         msg = "Unable to find 'status' in server response; Misconfigured URL?"
         print(msg)
         print("Server response: %s" % api_response)
-        raise Exception(msg)
-    if type(api_response) == dict and (api_response.get('status') == 'failed'):
-        if 'ProgrammingError' in api_response.get('exception_cls'):
-            raise DatabaseError(message='PyBossa database error.',
-                                error=api_response)
-        if ('DBIntegrityError' in api_response.get('exception_cls') and
-            'project' in api_response.get('target')):
-            msg = 'PyBossa project already exists.'
-            raise ProjectAlreadyExists(message=msg, error=api_response)
-        if 'project' in api_response.get('target'):
-            raise ProjectNotFound(message='PyBossa Project not found',
-                                  error=api_response)
-        if 'task' in api_response.get('target'):
-            raise TaskNotFound(message='PyBossa Task not found',
-                               error=api_response)
-        else:
-            print("Server response: %s" % api_response)
-            raise exceptions.HTTPError
+        raise Exception(msg)"""
+    if type(api_response) == dict and (api_response.get('status') == 'failed' or api_response.get('status_code') != 200 ):
+        if 'exception_cls' in api_response:
+            if 'ProgrammingError' in api_response.get('exception_cls'):
+                raise DatabaseError(message='PyBossa database error.',
+                                    error=api_response)
+            if ('DBIntegrityError' in api_response.get('exception_cls') and
+                'project' in api_response.get('target')):
+                msg = 'PyBossa project already exists.'
+                raise ProjectAlreadyExists(message=msg, error=api_response)
+
+        if 'target' in api_response:
+            if 'project' in api_response.get('target'):
+                raise ProjectNotFound(message='PyBossa Project not found',
+                                      error=api_response)
+            if 'task' in api_response.get('target'):
+                raise TaskNotFound(message='PyBossa Task not found',
+                                   error=api_response)
+        print("Server response: %s" % api_response)
+        raise exceptions.HTTPError
 
 
 def format_error(module, error):

--- a/helpers.py
+++ b/helpers.py
@@ -362,7 +362,7 @@ def find_project_by_short_name(short_name, pbclient, all=None):
 
 def check_api_error(api_response):
     """Check if returned API response contains an error."""
-    if 'status' not in api_response:
+    if type(api_response) == dict and 'status' not in api_response:
         msg = "Unable to find 'status' in server response; Misconfigured URL?"
         print(msg)
         print("Server response: %s" % api_response)
@@ -382,6 +382,7 @@ def check_api_error(api_response):
             raise TaskNotFound(message='PyBossa Task not found',
                                error=api_response)
         else:
+            print("Server response: %s" % api_response)
             raise exceptions.HTTPError
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -362,6 +362,11 @@ def find_project_by_short_name(short_name, pbclient, all=None):
 
 def check_api_error(api_response):
     """Check if returned API response contains an error."""
+    if 'status' not in api_response:
+        msg = "Unable to find 'status' in server response; Misconfigured URL?"
+        print(msg)
+        print("Server response: %s" % api_response)
+        raise Exception(msg)
     if type(api_response) == dict and (api_response.get('status') == 'failed'):
         if 'ProgrammingError' in api_response.get('exception_cls'):
             raise DatabaseError(message='PyBossa database error.',

--- a/helpers.py
+++ b/helpers.py
@@ -361,32 +361,29 @@ def find_project_by_short_name(short_name, pbclient, all=None):
 
 
 def check_api_error(api_response):
-    """Check if returned API response contains an error.
-    if type(api_response) == dict and 'status' not in api_response:
-        if 'status_code' in api_response and api_response['status_code'] <> 200
-        msg = "Unable to find 'status' in server response; Misconfigured URL?"
-        print(msg)
-        print("Server response: %s" % api_response)
-        raise Exception(msg)"""
-    if type(api_response) == dict and (api_response.get('status') == 'failed' or api_response.get('status_code') != 200 ):
-        if 'exception_cls' in api_response:
-            if 'ProgrammingError' in api_response.get('exception_cls'):
-                raise DatabaseError(message='PyBossa database error.',
-                                    error=api_response)
-            if ('DBIntegrityError' in api_response.get('exception_cls') and
-                'project' in api_response.get('target')):
-                msg = 'PyBossa project already exists.'
-                raise ProjectAlreadyExists(message=msg, error=api_response)
-
-        if 'target' in api_response:
-            if 'project' in api_response.get('target'):
-                raise ProjectNotFound(message='PyBossa Project not found',
-                                      error=api_response)
-            if 'task' in api_response.get('target'):
-                raise TaskNotFound(message='PyBossa Task not found',
-                                   error=api_response)
-        print("Server response: %s" % api_response)
-        raise exceptions.HTTPError
+    print(api_response)
+    """Check if returned API response contains an error."""
+    if type(api_response) == dict and 'code' in api_response and api_response['code'] <> 200:
+            print("Server response code: %s" % api_response['code'])
+            print("Server response: %s" % api_response)
+            raise exceptions.HTTPError('Unexpected response', response=api_response)
+    if type(api_response) == dict and (api_response.get('status') == 'failed'):
+        if 'ProgrammingError' in api_response.get('exception_cls'):
+            raise DatabaseError(message='PyBossa database error.',
+                                error=api_response)
+        if ('DBIntegrityError' in api_response.get('exception_cls') and
+            'project' in api_response.get('target')):
+            msg = 'PyBossa project already exists.'
+            raise ProjectAlreadyExists(message=msg, error=api_response)
+        if 'project' in api_response.get('target'):
+            raise ProjectNotFound(message='PyBossa Project not found',
+                                  error=api_response)
+        if 'task' in api_response.get('target'):
+            raise TaskNotFound(message='PyBossa Task not found',
+                               error=api_response)
+        else:
+            print("Server response: %s" % api_response)
+            raise exceptions.HTTPError('Unexpected response', response=api_response)
 
 
 def format_error(module, error):

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -55,7 +55,7 @@ class TestHelpers(TestDefault):
 
     def test_check_general_http_api_error_raises_exception(self):
         """Test check_api_error raises HTTPError exception."""
-        error = dict(status_code=500)
+        error = dict(code=500)
         assert_raises(exceptions.HTTPError, check_api_error, error)
 
     def test_check_api_error_raises_database_error(self):

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -53,6 +53,11 @@ class TestHelpers(TestDefault):
         error = dict(status='failed', target='diff', exception_cls='err')
         assert_raises(exceptions.HTTPError, check_api_error, error)
 
+    def test_check_general_http_api_error_raises_exception(self):
+        """Test check_api_error raises HTTPError exception."""
+        error = dict(status_code=500)
+        assert_raises(exceptions.HTTPError, check_api_error, error)
+
     def test_check_api_error_raises_database_error(self):
         """Test check_api_error raises DatabaseError exception."""
         error = dict(status='failed', target='diff',

--- a/test/test_pbs_create_project.py
+++ b/test/test_pbs_create_project.py
@@ -16,7 +16,7 @@ class TestPbsCreateProject(TestDefault):
     def test_create_project_create(self):
         """Test create_project works."""
         pbclient = MagicMock()
-        pbclient.create_project.return_value = {'short_name': 'short_name'}
+        pbclient.create_project.return_value = {'short_name': 'short_name', 'status_code': 200}
         self.config.pbclient = pbclient
         res = _create_project(self.config)
         assert res == 'Project: short_name created!', res


### PR DESCRIPTION
Ensure the payload contains a `status` attribute since existing code doesn't properly handle failure (i.e., assumes success if it doesn't see the failure it expects)