### PR TITLE
Issue 52

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -204,8 +204,6 @@ def _add_tasks(config, tasks_file, tasks_type, priority, redundancy):
         if len(data) == 0:
             return ("Unknown format for the tasks file. Use json, csv, po or "
                     "properties.")
-        # Check if for the data we have to auto-throttle task creation
-        sleep, msg = enable_auto_throttling(config, data)
         # If true, warn user
         # if sleep:  # pragma: no cover
         #     click.secho(msg, fg='yellow')
@@ -218,6 +216,7 @@ def _add_tasks(config, tasks_file, tasks_type, priority, redundancy):
                                                        n_answers=redundancy,
                                                        priority_0=priority)
 
+                # Check if for the data we have to auto-throttle task creation
                 sleep, msg = enable_auto_throttling(config, data)
                 check_api_error(response)
                 # If auto-throttling enabled, sleep for sleep seconds
@@ -241,13 +240,6 @@ def _add_helpingmaterials(config, helping_file, helping_type):
         if len(data) == 0:
             return ("Unknown format for the tasks file. Use json, csv, po or "
                     "properties.")
-        # Check if for the data we have to auto-throttle task creation
-        print enable_auto_throttling
-        sleep, msg = enable_auto_throttling(config, data,
-                                            endpoint='/api/helpinmaterial')
-        # If true, warn user
-        if sleep:  # pragma: no cover
-            click.secho(msg, fg='yellow')
         # Show progress bar
         with click.progressbar(data, label="Adding Helping Materials") as pgbar:
             for d in pgbar:
@@ -268,6 +260,12 @@ def _add_helpingmaterials(config, helping_file, helping_type):
                     response = config.pbclient.create_helpingmaterial(project_id=project.id,
                                                                       info=helping_info)
                 check_api_error(response)
+                # Check if for the data we have to auto-throttle task creation
+                sleep, msg = enable_auto_throttling(config, data,
+                                                    endpoint='/api/helpinmaterial')
+                # If true, warn user
+                if sleep:  # pragma: no cover
+                    click.secho(msg, fg='yellow')
                 # If auto-throttling enabled, sleep for sleep seconds
                 if sleep:  # pragma: no cover
                     time.sleep(sleep)
@@ -327,17 +325,14 @@ def _update_tasks_redundancy(config, task_id, redundancy, limit=300, offset=0):
             limit = limit
             offset = offset
             tasks = config.pbclient.get_tasks(project.id, limit, offset)
-            # Check if for the data we have to auto-throttle task update
-            sleep, msg = enable_auto_throttling(config, tasks)
-            # If true, warn user
-            if sleep:  # pragma: no cover
-                click.secho(msg, fg='yellow')
             with click.progressbar(tasks, label="Updating Tasks") as pgbar:
                 while len(tasks) > 0:
                     for t in pgbar:
                         t.n_answers = redundancy
                         response = config.pbclient.update_task(t)
                         check_api_error(response)
+                        # Check if for the data we have to auto-throttle task update
+                        sleep, msg = enable_auto_throttling(config, tasks)
                         # If auto-throttling enabled, sleep for sleep seconds
                         if sleep:  # pragma: no cover
                             time.sleep(sleep)

--- a/helpers.py
+++ b/helpers.py
@@ -437,8 +437,6 @@ def enable_auto_throttling(config, data, limit=299, endpoint='/api/task'):
     limit = server_limit or limit
     # Get reset time
     reset_epoch = int(headers.get('X-RateLimit-Reset', 0))
-    reset_time = datetime.datetime(1970, 1, 1) + \
-                 datetime.timedelta(seconds=reset_epoch)
     # Compute sleep time
     sleep = (reset_epoch -
              calendar.timegm(datetime.datetime.utcnow().utctimetuple()))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except (ImportError, OSError):
 
 setup(
     name="pybossa-pbs",
-    version="2.4.5",
+    version="2.4.6",
     author="Scifabric LTD",
     author_email="info@scifabric.com",
     description="PYBOSSA command line client",

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -7,6 +7,8 @@ from mock import patch, MagicMock
 from nose.tools import assert_raises
 from requests import exceptions
 from pbsexceptions import *
+import calendar
+import datetime
 
 
 class TestHelpers(TestDefault):
@@ -114,12 +116,15 @@ class TestHelpers(TestDefault):
         mock.return_value = MagicMock(['headers'])
         config = MagicMock(['server'])
 
-        mock.return_value.headers = {'X-RateLimit-Remaining': 9}
+        now = calendar.timegm(datetime.datetime.utcnow().utctimetuple()) + 10
+
+        mock.return_value.headers = {'X-RateLimit-Remaining': 9,
+                                     'X-RateLimit-Reset': now}
         sleep, msg = enable_auto_throttling(config, range(10))
         assert sleep > 0, "Throttling should be enabled"
         assert msg is not None, "Throttling should be enabled"
 
-        mock.return_value.headers = {'X-RateLimit-Remaining': 10}
+        mock.return_value.headers = {'X-RateLimit-Remaining': 11}
         sleep, msg = enable_auto_throttling(config, range(10))
         assert sleep == 0, "Throttling should not be enabled"
         assert msg is None, "Throttling should not be enabled"


### PR DESCRIPTION
@corrado9999 I've modified your method because it doesn't work when you have thousands of tasks. As you only called it once, when the client does the requests.head, the issue is that you have to wait equally among each datum within the list of the data. This is a problem, because if I try to upload 5000 tasks, it will wait a lot.

The best approach is to consume all the hits (almost all of them) and then, wait the remaining available window, so we can go again against that limit. This will work if the server changes the Limit and if we have several clients running in parallel.  

I hope you like it :D